### PR TITLE
chore(database): Create seeders for Blocks and Tracks from legacy data

### DIFF
--- a/database/seeders/BlocoSeeder.php
+++ b/database/seeders/BlocoSeeder.php
@@ -1,0 +1,163 @@
+<?php
+
+namespace Database\Seeders;
+
+use Illuminate\Database\Seeder;
+use Illuminate\Support\Facades\DB;
+
+class BlocoSeeder extends Seeder
+{
+    /**
+     * Seed blocos and bloco_disciplinas tables with data from legacy system (DefinirBloco2018.java).
+     *
+     * Course: 45024 (Math Education - Licenciatura em Matemática)
+     * Curriculum codes: 450240001181, 450240004181
+     */
+    public function run(): void
+    {
+        $codcrls = ['450240001181', '450240004181'];
+
+        foreach ($codcrls as $codcrl) {
+            // Bloco: Introdução aos Estudos da Educação
+            $blocoId = DB::table('blocos')->insertGetId([
+                'nome' => 'Introdução aos Estudos da Educação',
+                'codcrl' => $codcrl,
+                'creditos_aula_exigidos' => 4,
+                'creditos_trabalho_exigidos' => 0,
+                'num_disciplinas_exigidas' => 1,
+                'created_at' => now(),
+                'updated_at' => now(),
+            ]);
+
+            $disciplinas = ['EDF0285', 'EDF0287', 'EDF0289', 'PSA5100', 'PSA5201', 'PSE5142', 'FLH0423'];
+            foreach ($disciplinas as $coddis) {
+                DB::table('bloco_disciplinas')->insert([
+                    'bloco_id' => $blocoId,
+                    'coddis' => $coddis,
+                ]);
+            }
+
+            // Bloco: Psicologia da Educação
+            $blocoId = DB::table('blocos')->insertGetId([
+                'nome' => 'Psicologia da Educação',
+                'codcrl' => $codcrl,
+                'creditos_aula_exigidos' => 4,
+                'creditos_trabalho_exigidos' => 0,
+                'num_disciplinas_exigidas' => 1,
+                'created_at' => now(),
+                'updated_at' => now(),
+            ]);
+
+            $disciplinas = ['EDF0290', 'EDF0292', 'EDF0294', 'EDF0296', 'EDF0298'];
+            foreach ($disciplinas as $coddis) {
+                DB::table('bloco_disciplinas')->insert([
+                    'bloco_id' => $blocoId,
+                    'coddis' => $coddis,
+                ]);
+            }
+
+            // Bloco: Eletivas de Estágio da FE
+            $blocoId = DB::table('blocos')->insertGetId([
+                'nome' => 'Eletivas de Estágio da FE',
+                'codcrl' => $codcrl,
+                'creditos_aula_exigidos' => 8,
+                'creditos_trabalho_exigidos' => 0,
+                'num_disciplinas_exigidas' => 1,
+                'created_at' => now(),
+                'updated_at' => now(),
+            ]);
+
+            $disciplinas = ['EDM0425', 'EDM0426', 'EDM0685'];
+            foreach ($disciplinas as $coddis) {
+                DB::table('bloco_disciplinas')->insert([
+                    'bloco_id' => $blocoId,
+                    'coddis' => $coddis,
+                ]);
+            }
+
+            // Bloco: Libras
+            $blocoId = DB::table('blocos')->insertGetId([
+                'nome' => 'Libras',
+                'codcrl' => $codcrl,
+                'creditos_aula_exigidos' => 4,
+                'creditos_trabalho_exigidos' => 0,
+                'num_disciplinas_exigidas' => 1,
+                'created_at' => now(),
+                'updated_at' => now(),
+            ]);
+
+            $disciplinas = ['FLL1024', 'EDM0400'];
+            foreach ($disciplinas as $coddis) {
+                DB::table('bloco_disciplinas')->insert([
+                    'bloco_id' => $blocoId,
+                    'coddis' => $coddis,
+                ]);
+            }
+
+            // Bloco: Aprof. Licenciatura
+            $blocoId = DB::table('blocos')->insertGetId([
+                'nome' => 'Aprof. Licenciatura',
+                'codcrl' => $codcrl,
+                'creditos_aula_exigidos' => 8,
+                'creditos_trabalho_exigidos' => 0,
+                'num_disciplinas_exigidas' => 2,
+                'created_at' => now(),
+                'updated_at' => now(),
+            ]);
+
+            $disciplinas = [
+                'MAT0130', 'MAT0320', 'MAT0349', 'MAT0223', 'MAT0233', 'MAC0228', 'MAT0419', 'MAT0430',
+                'MAC0228', 'MAC0122', 'MAP0335', 'MAC0212', 'MAE0221', 'MAE0311', 'MAE0217', 'MAE0228',
+                '4300254', '4300255', '4300271', '4300357', '4300372', '4300373', '4300374', '4300259',
+                '4300405', '4300266', '4300351', 'AGA0105', '4300356', '4300358', 'EDM0425', 'EDM0426',
+            ];
+            foreach ($disciplinas as $coddis) {
+                DB::table('bloco_disciplinas')->insert([
+                    'bloco_id' => $blocoId,
+                    'coddis' => $coddis,
+                ]);
+            }
+
+            // Bloco: Aprof. Licenciatura (Prática)
+            $blocoId = DB::table('blocos')->insertGetId([
+                'nome' => 'Aprof. Licenciatura (Prática) ',
+                'codcrl' => $codcrl,
+                'creditos_aula_exigidos' => 8,
+                'creditos_trabalho_exigidos' => 0,
+                'num_disciplinas_exigidas' => 2,
+                'created_at' => now(),
+                'updated_at' => now(),
+            ]);
+
+            $disciplinas = ['MAT0412', 'MAT0450', 'MAE1514', 'MAC0118'];
+            foreach ($disciplinas as $coddis) {
+                DB::table('bloco_disciplinas')->insert([
+                    'bloco_id' => $blocoId,
+                    'coddis' => $coddis,
+                ]);
+            }
+
+            // Bloco: AACC (Atividades Acadêmico Científico Culturais)
+            $blocoId = DB::table('blocos')->insertGetId([
+                'nome' => 'AACC',
+                'codcrl' => $codcrl,
+                'creditos_aula_exigidos' => 0,
+                'creditos_trabalho_exigidos' => 0,
+                'num_disciplinas_exigidas' => 0,
+                'created_at' => now(),
+                'updated_at' => now(),
+            ]);
+
+            $disciplinas = [
+                '4502401', '4502402', '4502403', '4502404', '4502405', '4502406', '4502407', '4502408',
+                '4502409', '4502410', '4810001', '4810002', '4810003', '4810004', '4810005',
+            ];
+            foreach ($disciplinas as $coddis) {
+                DB::table('bloco_disciplinas')->insert([
+                    'bloco_id' => $blocoId,
+                    'coddis' => $coddis,
+                ]);
+            }
+        }
+    }
+}

--- a/database/seeders/DatabaseSeeder.php
+++ b/database/seeders/DatabaseSeeder.php
@@ -24,7 +24,8 @@ class DatabaseSeeder extends Seeder
         $this->call([
             RoleSeeder::class,
             FilamentAdminSeeder::class,
-            // Other seeders can be added here
+            BlocoSeeder::class,
+            TrilhaSeeder::class,
         ]);
     }
 }

--- a/database/seeders/TrilhaSeeder.php
+++ b/database/seeders/TrilhaSeeder.php
@@ -1,0 +1,280 @@
+<?php
+
+namespace Database\Seeders;
+
+use Illuminate\Database\Seeder;
+use Illuminate\Support\Facades\DB;
+
+class TrilhaSeeder extends Seeder
+{
+    /**
+     * Seed trilhas, trilha_regras, and trilha_disciplinas tables with data from legacy system.
+     *
+     * Course: 45052 (Computer Science - Bacharelado em Ciência da Computação)
+     * Sources: TrilhaCienciaDados.java, TrilhaInteligenciaArtificial.java,
+     *          TrilhaSistemasSoftware.java, TrilhaTeoriaComputacao.java
+     */
+    public function run(): void
+    {
+        $codcrl = '45052'; // Computer Science course code
+
+        // ===========================
+        // Trilha: Ciência de Dados
+        // ===========================
+        $trilhaId = DB::table('trilhas')->insertGetId([
+            'nome' => 'Ciência de Dados',
+            'codcrl' => $codcrl,
+            'created_at' => now(),
+            'updated_at' => now(),
+        ]);
+
+        // Núcleo: 5 obrigatórias + 2 eletivas = 7 disciplinas total
+        $regraId = DB::table('trilha_regras')->insertGetId([
+            'trilha_id' => $trilhaId,
+            'nome_regra' => 'Núcleo',
+            'num_disciplinas_exigidas' => 7,
+            'created_at' => now(),
+            'updated_at' => now(),
+        ]);
+
+        $obrigatorias = ['MAC0317', 'MAC0426', 'MAC0431', 'MAC0460', 'MAE0221'];
+        foreach ($obrigatorias as $coddis) {
+            DB::table('trilha_disciplinas')->insert([
+                'regra_id' => $regraId,
+                'coddis' => $coddis,
+                'tipo' => 'obrigatoria',
+            ]);
+        }
+
+        $eletivas = ['MAC0315', 'MAC0325', 'MAC0427', 'MAE0312', 'MAE0228'];
+        foreach ($eletivas as $coddis) {
+            DB::table('trilha_disciplinas')->insert([
+                'regra_id' => $regraId,
+                'coddis' => $coddis,
+                'tipo' => 'eletiva',
+            ]);
+        }
+
+        // ===========================
+        // Trilha: Inteligência Artificial
+        // ===========================
+        $trilhaId = DB::table('trilhas')->insertGetId([
+            'nome' => 'Inteligência Artificial',
+            'codcrl' => $codcrl,
+            'created_at' => now(),
+            'updated_at' => now(),
+        ]);
+
+        // Regra 1: IA Intro (1 obrigatória + 2 eletivas = 3 disciplinas)
+        $regraId = DB::table('trilha_regras')->insertGetId([
+            'trilha_id' => $trilhaId,
+            'nome_regra' => 'IA Intro',
+            'num_disciplinas_exigidas' => 3,
+            'created_at' => now(),
+            'updated_at' => now(),
+        ]);
+
+        DB::table('trilha_disciplinas')->insert([
+            'regra_id' => $regraId,
+            'coddis' => 'MAC0425',
+            'tipo' => 'obrigatoria',
+        ]);
+
+        $eletivas = ['MAC0444', 'MAC0459', 'MAC0460'];
+        foreach ($eletivas as $coddis) {
+            DB::table('trilha_disciplinas')->insert([
+                'regra_id' => $regraId,
+                'coddis' => $coddis,
+                'tipo' => 'eletiva',
+            ]);
+        }
+
+        // Regra 2: IA Sistemas (2 eletivas)
+        $regraId = DB::table('trilha_regras')->insertGetId([
+            'trilha_id' => $trilhaId,
+            'nome_regra' => 'IA Sistemas',
+            'num_disciplinas_exigidas' => 2,
+            'created_at' => now(),
+            'updated_at' => now(),
+        ]);
+
+        $eletivas = ['MAC0218', 'MAC0332', 'MAC0413', 'MAC0472'];
+        foreach ($eletivas as $coddis) {
+            DB::table('trilha_disciplinas')->insert([
+                'regra_id' => $regraId,
+                'coddis' => $coddis,
+                'tipo' => 'eletiva',
+            ]);
+        }
+
+        // Regra 3: IA Teoria (1 eletiva)
+        $regraId = DB::table('trilha_regras')->insertGetId([
+            'trilha_id' => $trilhaId,
+            'nome_regra' => 'IA Teoria',
+            'num_disciplinas_exigidas' => 1,
+            'created_at' => now(),
+            'updated_at' => now(),
+        ]);
+
+        $eletivas = ['MAC0414', 'MAE0320', 'MAE0399', 'MAE0515', 'MAT0359'];
+        foreach ($eletivas as $coddis) {
+            DB::table('trilha_disciplinas')->insert([
+                'regra_id' => $regraId,
+                'coddis' => $coddis,
+                'tipo' => 'eletiva',
+            ]);
+        }
+
+        // ===========================
+        // Trilha: Sistemas de Software
+        // ===========================
+        $trilhaId = DB::table('trilhas')->insertGetId([
+            'nome' => 'Sistemas de Software',
+            'codcrl' => $codcrl,
+            'created_at' => now(),
+            'updated_at' => now(),
+        ]);
+
+        // Regra 1: Desenvolvimento de Software (4 obrigatórias)
+        $regraId = DB::table('trilha_regras')->insertGetId([
+            'trilha_id' => $trilhaId,
+            'nome_regra' => 'Desenvolvimento de Software',
+            'num_disciplinas_exigidas' => 4,
+            'created_at' => now(),
+            'updated_at' => now(),
+        ]);
+
+        $obrigatorias = ['MAC0218', 'MAC0332', 'MAC0413', 'MAC0472'];
+        foreach ($obrigatorias as $coddis) {
+            DB::table('trilha_disciplinas')->insert([
+                'regra_id' => $regraId,
+                'coddis' => $coddis,
+                'tipo' => 'obrigatoria',
+            ]);
+        }
+
+        // Regra 2: Banco de Dados (2 eletivas)
+        $regraId = DB::table('trilha_regras')->insertGetId([
+            'trilha_id' => $trilhaId,
+            'nome_regra' => 'Banco de Dados',
+            'num_disciplinas_exigidas' => 2,
+            'created_at' => now(),
+            'updated_at' => now(),
+        ]);
+
+        $eletivas = ['MAC0426', 'MAC0439', 'MAC0459'];
+        foreach ($eletivas as $coddis) {
+            DB::table('trilha_disciplinas')->insert([
+                'regra_id' => $regraId,
+                'coddis' => $coddis,
+                'tipo' => 'eletiva',
+            ]);
+        }
+
+        // Regra 3: Sistemas Paralelos e Distribuídos (3 eletivas)
+        $regraId = DB::table('trilha_regras')->insertGetId([
+            'trilha_id' => $trilhaId,
+            'nome_regra' => 'Sistemas Paralelos e Distribuídos',
+            'num_disciplinas_exigidas' => 3,
+            'created_at' => now(),
+            'updated_at' => now(),
+        ]);
+
+        $eletivas = ['MAC0219', 'MAC0344', 'MAC0352', 'MAC0463', 'MAC0469', 'MAC0471'];
+        foreach ($eletivas as $coddis) {
+            DB::table('trilha_disciplinas')->insert([
+                'regra_id' => $regraId,
+                'coddis' => $coddis,
+                'tipo' => 'eletiva',
+            ]);
+        }
+
+        // ===========================
+        // Trilha: Teoria da Computação
+        // ===========================
+        $trilhaId = DB::table('trilhas')->insertGetId([
+            'nome' => 'Teoria da Computação',
+            'codcrl' => $codcrl,
+            'created_at' => now(),
+            'updated_at' => now(),
+        ]);
+
+        // Regra 1: Obrigatórias de Algoritmos (2 obrigatórias)
+        $regraId = DB::table('trilha_regras')->insertGetId([
+            'trilha_id' => $trilhaId,
+            'nome_regra' => 'Obrigatórias de Algoritmos',
+            'num_disciplinas_exigidas' => 2,
+            'created_at' => now(),
+            'updated_at' => now(),
+        ]);
+
+        $obrigatorias = ['MAC0328', 'MAC0414'];
+        foreach ($obrigatorias as $coddis) {
+            DB::table('trilha_disciplinas')->insert([
+                'regra_id' => $regraId,
+                'coddis' => $coddis,
+                'tipo' => 'obrigatoria',
+            ]);
+        }
+
+        // Regra 2: Obrigatórias de Matemática (3 obrigatórias)
+        $regraId = DB::table('trilha_regras')->insertGetId([
+            'trilha_id' => $trilhaId,
+            'nome_regra' => 'Obrigatórias de Matemática',
+            'num_disciplinas_exigidas' => 3,
+            'created_at' => now(),
+            'updated_at' => now(),
+        ]);
+
+        $obrigatorias = ['MAC0320', 'MAT0206', 'MAT0264'];
+        foreach ($obrigatorias as $coddis) {
+            DB::table('trilha_disciplinas')->insert([
+                'regra_id' => $regraId,
+                'coddis' => $coddis,
+                'tipo' => 'obrigatoria',
+            ]);
+        }
+
+        // Regra 3: Obrigatórias de Otimização (2 obrigatórias)
+        $regraId = DB::table('trilha_regras')->insertGetId([
+            'trilha_id' => $trilhaId,
+            'nome_regra' => 'Obrigatórias de Otimização',
+            'num_disciplinas_exigidas' => 2,
+            'created_at' => now(),
+            'updated_at' => now(),
+        ]);
+
+        $obrigatorias = ['MAC0315', 'MAC0325'];
+        foreach ($obrigatorias as $coddis) {
+            DB::table('trilha_disciplinas')->insert([
+                'regra_id' => $regraId,
+                'coddis' => $coddis,
+                'tipo' => 'obrigatoria',
+            ]);
+        }
+
+        // Regra 4: Total de 7 Disciplinas (todas as da trilha como eletivas)
+        $regraId = DB::table('trilha_regras')->insertGetId([
+            'trilha_id' => $trilhaId,
+            'nome_regra' => 'Total de 7 Disciplinas',
+            'num_disciplinas_exigidas' => 7,
+            'created_at' => now(),
+            'updated_at' => now(),
+        ]);
+
+        $todasDisciplinas = [
+            'MAC0328', 'MAC0414', 'MAC0325', 'MAC0327', 'MAC0331', 'MAC0336', 'MAC0450', 'MAC0465',
+            'MAC0466', 'MAC0320', 'MAT0206', 'MAT0264', 'MAC0414', 'MAC0436', 'MAE0221', 'MAE0224',
+            'MAE0228', 'MAE0326', 'MAT0225', 'MAT0234', 'MAT0265', 'MAT0311', 'MAC0315', 'MAC0325',
+            'MAC0300', 'MAC0343', 'MAC0418', 'MAC0419', 'MAC0427', 'MAC0450', 'MAC0452', 'MAC0461',
+            'MAC0473',
+        ];
+        foreach ($todasDisciplinas as $coddis) {
+            DB::table('trilha_disciplinas')->insert([
+                'regra_id' => $regraId,
+                'coddis' => $coddis,
+                'tipo' => 'eletiva',
+            ]);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
This PR creates seeders for `Blocos` (Blocks) and `Trilhas` (Tracks) by migrating hardcoded data from the legacy Java system into the database.

## Changes Made
- Created `database/seeders/BlocoSeeder.php` to populate `blocos` and `bloco_disciplinas` tables.
- Created `database/seeders/TrilhaSeeder.php` to populate `trilhas`, `trilha_regras`, and `trilha_disciplinas` tables.
- Updated `database/seeders/DatabaseSeeder.php` to call `BlocoSeeder` and `TrilhaSeeder`.

## Related Issues
Closes #13