### PR TITLE
feat(replicado-service): Implement ReplicadoService with comprehensive data retrieval and error handling

### DIFF
--- a/app/Exceptions/ReplicadoServiceException.php
+++ b/app/Exceptions/ReplicadoServiceException.php
@@ -3,12 +3,89 @@
 namespace App\Exceptions;
 
 use Exception;
+use Throwable;
 
 /**
- * Exceção customizada para erros originados no ReplicadoService.
+ * Exception thrown when ReplicadoService encounters an error.
+ *
+ * This exception is used to wrap any errors that occur when interacting
+ * with the USP Replicado database, such as connection failures, query errors,
+ * or data retrieval issues.
  */
 class ReplicadoServiceException extends Exception
 {
-    // You can add custom properties or methods to this exception if needed in the future.
-    // For example, a constructor that accepts a specific error code or context.
+    /**
+     * Create a new ReplicadoServiceException instance.
+     *
+     * @param  string  $message  The exception message
+     * @param  int  $code  The exception code (default: 0)
+     * @param  Throwable|null  $previous  The previous exception for exception chaining
+     */
+    public function __construct(string $message = '', int $code = 0, ?Throwable $previous = null)
+    {
+        parent::__construct($message, $code, $previous);
+    }
+
+    /**
+     * Create an exception for database connection failures.
+     *
+     * @param  Throwable  $previous  The original exception
+     */
+    public static function connectionFailed(Throwable $previous): self
+    {
+        return new self(
+            __('Unable to connect to Replicado database. Please check your connection settings.'),
+            500,
+            $previous
+        );
+    }
+
+    /**
+     * Create an exception for query execution failures.
+     *
+     * @param  string  $query  The query that failed
+     * @param  Throwable  $previous  The original exception
+     */
+    public static function queryFailed(string $query, Throwable $previous): self
+    {
+        return new self(
+            __('Failed to execute Replicado query: :query', ['query' => $query]),
+            500,
+            $previous
+        );
+    }
+
+    /**
+     * Create an exception for when a resource is not found.
+     *
+     * @param  string  $resource  The resource type that was not found
+     * @param  int|string  $identifier  The identifier that was searched for
+     */
+    public static function notFound(string $resource, int|string $identifier): self
+    {
+        return new self(
+            __(':resource not found with identifier: :identifier', [
+                'resource' => $resource,
+                'identifier' => (string) $identifier,
+            ]),
+            404
+        );
+    }
+
+    /**
+     * Create an exception for invalid parameters.
+     *
+     * @param  string  $parameter  The parameter name
+     * @param  string  $reason  The reason why the parameter is invalid
+     */
+    public static function invalidParameter(string $parameter, string $reason): self
+    {
+        return new self(
+            __('Invalid parameter :parameter: :reason', [
+                'parameter' => $parameter,
+                'reason' => $reason,
+            ]),
+            400
+        );
+    }
 }

--- a/app/Providers/ReplicadoServiceProvider.php
+++ b/app/Providers/ReplicadoServiceProvider.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace App\Providers;
+
+use App\Services\ReplicadoService;
+use Illuminate\Support\ServiceProvider;
+
+/**
+ * Service provider for ReplicadoService.
+ *
+ * Registers the ReplicadoService as a singleton in the container,
+ * allowing for dependency injection throughout the application.
+ */
+class ReplicadoServiceProvider extends ServiceProvider
+{
+    /**
+     * Register services.
+     */
+    public function register(): void
+    {
+        $this->app->singleton(ReplicadoService::class, function ($app) {
+            return new ReplicadoService;
+        });
+    }
+
+    /**
+     * Bootstrap services.
+     */
+    public function boot(): void
+    {
+        //
+    }
+}

--- a/app/Services/ReplicadoService.php
+++ b/app/Services/ReplicadoService.php
@@ -2,60 +2,315 @@
 
 namespace App\Services;
 
-use App\Exceptions\ReplicadoServiceException; // Import custom exception
-use Illuminate\Support\Facades\Log;
+use App\Exceptions\ReplicadoServiceException;
+use Illuminate\Support\Collection;
+use PDOException;
+use Throwable;
+use Uspdev\Replicado\DB as ReplicadoDB;
+use Uspdev\Replicado\Graduacao;
 use Uspdev\Replicado\Pessoa;
 
 /**
- * Classe de serviço para interagir com o banco de dados Replicado da USP.
+ * Service for interacting with USP Replicado database.
+ *
+ * This service centralizes all interactions with the Replicado database,
+ * providing a clean abstraction layer over the uspdev/replicado package.
+ * It handles error management and data transformation consistently.
  */
 class ReplicadoService
 {
     /**
-     * Valida se o Número USP (codpes) e o e-mail fornecidos pertencem à mesma pessoa válida no Replicado.
+     * Fetch student data by USP code (NUSP).
      *
-     * Este método consulta o Replicado para verificar a existência do `codpes`
-     * e se o `email` fornecido está associado a esse `codpes`.
+     * Returns comprehensive student information including personal data
+     * and current enrollment details.
      *
-     * @param  int  $codpes  O Número USP (NUSP).
-     * @param  string  $email  O endereço de e-mail para validar em conjunto com o `codpes`.
-     * @return bool Retorna `true` se o `codpes` e o `email` corresponderem a uma pessoa válida, `false` caso contrário.
+     * @param  int  $codpes  Student USP code (NUSP)
+     * @return array{codpes: int, nompes: string|null, dtanas: string|null, email: string|null, codcur: int|null, nomcur: string|null, codhab: int|null, nomhab: string|null, dtainivin: string|null} Student data
      *
-     * @throws \App\Exceptions\ReplicadoServiceException Se ocorrer um problema de comunicação com o banco de dados Replicado.
+     * @throws ReplicadoServiceException When student not found or database error occurs
      */
-    public function validarNuspEmail(int $codpes, string $email): bool
+    public function buscarAluno(int $codpes): array
     {
-        if (! str_ends_with(strtolower($email), 'usp.br')) {
-            Log::warning("Replicado Validation: Attempt to validate non-USP email '{$email}' for codpes {$codpes}.");
-            // Depending on strictness, this might be an early return false or even an exception.
-            // For now, let it proceed to check against Replicado records.
-        }
-
         try {
-            $emailsPessoa = Pessoa::emails($codpes);
-
-            if (empty($emailsPessoa)) {
-                Log::info("Replicado Validation: No person found or no emails registered for codpes {$codpes}.");
-
-                return false;
+            // Validate parameter
+            if ($codpes <= 0) {
+                throw ReplicadoServiceException::invalidParameter('codpes', __('Must be a positive integer'));
             }
 
-            foreach ($emailsPessoa as $emailCadastrado) {
-                if (is_string($emailCadastrado) && (strtolower(trim($emailCadastrado)) === strtolower($email))) {
-                    Log::info("Replicado Validation: Success for codpes {$codpes} and email '{$email}'.");
+            // Fetch basic personal data
+            $pessoaData = Pessoa::dump($codpes);
 
-                    return true;
-                }
+            if (empty($pessoaData)) {
+                throw ReplicadoServiceException::notFound(__('Student'), $codpes);
             }
 
-            Log::info("Replicado Validation: Email '{$email}' does not match registered emails for codpes {$codpes}.");
+            // Fetch active course data
+            $cursoData = Graduacao::obterCursoAtivo($codpes);
 
-            return false;
+            // Fetch email
+            $email = Pessoa::email($codpes);
 
-        } catch (\Exception $e) {
-            Log::error("Replicado Service Error: Failed validating codpes {$codpes} and email '{$email}'. Error: ".$e->getMessage(), ['exception' => $e]);
-            // Re-throw as a custom, more specific exception for better handling by callers.
-            throw new ReplicadoServiceException('Replicado service communication error while validating NUSP/email.', 0, $e);
+            // Build structured response with explicit type casting
+            /** @var int $resultCodepes */
+            $resultCodepes = $pessoaData['codpes'] ?? $codpes;
+            /** @var string|null $resultNompes */
+            $resultNompes = $pessoaData['nompes'] ?? null;
+            /** @var string|null $resultDtanas */
+            $resultDtanas = $pessoaData['dtanas'] ?? null;
+            /** @var int|null $resultCodcur */
+            $resultCodcur = $cursoData['codcur'] ?? null;
+            /** @var string|null $resultNomcur */
+            $resultNomcur = $cursoData['nomcur'] ?? null;
+            /** @var int|null $resultCodhab */
+            $resultCodhab = $cursoData['codhab'] ?? null;
+            /** @var string|null $resultNomhab */
+            $resultNomhab = $cursoData['nomhab'] ?? null;
+            /** @var string|null $resultDtainivin */
+            $resultDtainivin = $cursoData['dtainivin'] ?? null;
+
+            return [
+                'codpes' => $resultCodepes,
+                'nompes' => $resultNompes,
+                'dtanas' => $resultDtanas,
+                'email' => $email ?: null,
+                'codcur' => $resultCodcur,
+                'nomcur' => $resultNomcur,
+                'codhab' => $resultCodhab,
+                'nomhab' => $resultNomhab,
+                'dtainivin' => $resultDtainivin,
+            ];
+        } catch (PDOException $e) {
+            throw ReplicadoServiceException::connectionFailed($e);
+        } catch (ReplicadoServiceException $e) {
+            throw $e;
+        } catch (Throwable $e) {
+            throw new ReplicadoServiceException(
+                __('Error fetching student data: :message', ['message' => $e->getMessage()]),
+                500,
+                $e
+            );
+        }
+    }
+
+    /**
+     * Fetch student academic history by USP code and program code.
+     *
+     * Returns a collection of all courses taken by the student in the specified program,
+     * including grades, attendance, and course details.
+     *
+     * @param  int  $codpes  Student USP code (NUSP)
+     * @param  int  $codpgm  Program code
+     * @return Collection<int, array{codpes: int|string, codpgm: int|string, coddis: string, verdis: int, codtur: string, notfim: float|null, frqfim: float|null, rstfim: string, discrl: string, stamtr: string, dtavalfim: string|null, nomdis: string, creaul: int, cretra: int}> Collection of academic history records
+     *
+     * @throws ReplicadoServiceException When database error occurs
+     */
+    public function buscarHistorico(int $codpes, int $codpgm): Collection
+    {
+        try {
+            // Validate parameters
+            if ($codpes <= 0) {
+                throw ReplicadoServiceException::invalidParameter('codpes', __('Must be a positive integer'));
+            }
+
+            if ($codpgm <= 0) {
+                throw ReplicadoServiceException::invalidParameter('codpgm', __('Must be a positive integer'));
+            }
+
+            $query = "
+                SELECT
+                    H.codpes,
+                    H.codpgm,
+                    H.coddis,
+                    H.verdis,
+                    H.codtur,
+                    H.notfim,
+                    H.frqfim,
+                    H.rstfim,
+                    H.discrl,
+                    H.stamtr,
+                    H.dtavalfim,
+                    D.nomdis,
+                    D.creaul,
+                    D.cretra
+                FROM HISTESCOLARGR H
+                INNER JOIN DISCIPLINAGR D ON H.coddis = D.coddis AND H.verdis = D.verdis
+                WHERE H.codpes = CONVERT(int, :codpes)
+                  AND H.codpgm = CONVERT(int, :codpgm)
+                  AND H.stamtr IN ('M', 'E')
+                ORDER BY H.dtavalfim DESC
+            ";
+
+            $params = [
+                'codpes' => $codpes,
+                'codpgm' => $codpgm,
+            ];
+
+            /** @var array<int, array{codpes: int|string, codpgm: int|string, coddis: string, verdis: int, codtur: string, notfim: float|null, frqfim: float|null, rstfim: string, discrl: string, stamtr: string, dtavalfim: string|null, nomdis: string, creaul: int, cretra: int}> $result */
+            $result = ReplicadoDB::fetchAll($query, $params);
+
+            return collect($result);
+        } catch (PDOException $e) {
+            throw ReplicadoServiceException::connectionFailed($e);
+        } catch (ReplicadoServiceException $e) {
+            throw $e;
+        } catch (Throwable $e) {
+            throw ReplicadoServiceException::queryFailed('buscarHistorico', $e);
+        }
+    }
+
+    /**
+     * Fetch curriculum structure by curriculum code.
+     *
+     * Returns complete curriculum information including basic data
+     * and all disciplines that compose the curriculum.
+     *
+     * @param  string  $codcrl  Curriculum code
+     * @return array{curriculo: array<string, mixed>, disciplinas: Collection<int, array{coddis: string, verdis: int, tipobg: string, numsemidl: int, nomdis: string, creaul: int, cretra: int}>} Curriculum data
+     *
+     * @throws ReplicadoServiceException When curriculum not found or database error occurs
+     */
+    public function buscarGradeCurricular(string $codcrl): array
+    {
+        try {
+            // Validate parameter
+            if (empty(trim($codcrl))) {
+                throw ReplicadoServiceException::invalidParameter('codcrl', __('Cannot be empty'));
+            }
+
+            // Fetch curriculum basic data
+            $curriculoQuery = '
+                SELECT
+                    codcrl,
+                    dtainicrl,
+                    dtafimcrl,
+                    numdiaintmin,
+                    numdiaintmax,
+                    dtainivencrl,
+                    numcredaulobg,
+                    numcredaulopc,
+                    numcredaulopt,
+                    numcredtrbopc
+                FROM CURRICULOGR
+                WHERE codcrl = :codcrl
+            ';
+
+            /** @var array<string, mixed>|false $curriculoData */
+            $curriculoData = ReplicadoDB::fetch($curriculoQuery, ['codcrl' => $codcrl]);
+
+            if (empty($curriculoData)) {
+                throw ReplicadoServiceException::notFound(__('Curriculum'), $codcrl);
+            }
+
+            // Fetch curriculum disciplines
+            $disciplinasQuery = '
+                SELECT
+                    G.coddis,
+                    G.verdis,
+                    G.tipobg,
+                    G.numsemidl,
+                    D.nomdis,
+                    D.creaul,
+                    D.cretra
+                FROM GRADECURRICULAR G
+                INNER JOIN DISCIPLINAGR D ON G.coddis = D.coddis AND G.verdis = D.verdis
+                WHERE G.codcrl = :codcrl
+                ORDER BY G.numsemidl, D.nomdis
+            ';
+
+            /** @var array<int, array{coddis: string, verdis: int, tipobg: string, numsemidl: int, nomdis: string, creaul: int, cretra: int}> $disciplinas */
+            $disciplinas = ReplicadoDB::fetchAll($disciplinasQuery, ['codcrl' => $codcrl]);
+
+            return [
+                'curriculo' => $curriculoData,
+                'disciplinas' => collect($disciplinas),
+            ];
+        } catch (PDOException $e) {
+            throw ReplicadoServiceException::connectionFailed($e);
+        } catch (ReplicadoServiceException $e) {
+            throw $e;
+        } catch (Throwable $e) {
+            throw ReplicadoServiceException::queryFailed('buscarGradeCurricular', $e);
+        }
+    }
+
+    /**
+     * Fetch equivalence rules for a discipline in a specific curriculum.
+     *
+     * Returns all equivalence groups and their component disciplines
+     * that can substitute the target discipline.
+     *
+     * @param  string  $coddis  Discipline code
+     * @param  string  $codcrl  Curriculum code
+     * @return Collection<int, array{codeqv: int, disciplinas_equivalentes: Collection<int, array{coddis: string, verdis: int, nomdis: string}>}> Collection of equivalence groups
+     *
+     * @throws ReplicadoServiceException When database error occurs
+     */
+    public function buscarEquivalencias(string $coddis, string $codcrl): Collection
+    {
+        try {
+            // Validate parameters
+            if (empty(trim($coddis))) {
+                throw ReplicadoServiceException::invalidParameter('coddis', __('Cannot be empty'));
+            }
+
+            if (empty(trim($codcrl))) {
+                throw ReplicadoServiceException::invalidParameter('codcrl', __('Cannot be empty'));
+            }
+
+            // First, find equivalence groups that include this discipline for this curriculum
+            $gruposQuery = '
+                SELECT DISTINCT G.codeqv
+                FROM GRUPOEQUIVGR G
+                WHERE G.coddis = :coddis
+                  AND G.codcrl = :codcrl
+            ';
+
+            /** @var array<int, array{codeqv: int}> $grupos */
+            $grupos = ReplicadoDB::fetchAll($gruposQuery, [
+                'coddis' => $coddis,
+                'codcrl' => $codcrl,
+            ]);
+
+            if (empty($grupos)) {
+                /** @var Collection<int, array{codeqv: int, disciplinas_equivalentes: Collection<int, array{coddis: string, verdis: int, nomdis: string}>}> */
+                return collect([]);
+            }
+
+            // For each group, fetch all equivalent disciplines
+            /** @var Collection<int, array{codeqv: int, disciplinas_equivalentes: Collection<int, array{coddis: string, verdis: int, nomdis: string}>}> $equivalencias */
+            $equivalencias = collect();
+
+            foreach ($grupos as $grupo) {
+                $codeqv = $grupo['codeqv'];
+
+                $disciplinasQuery = '
+                    SELECT
+                        E.coddis,
+                        E.verdis,
+                        D.nomdis
+                    FROM EQUIVALENCIAGR E
+                    INNER JOIN DISCIPLINAGR D ON E.coddis = D.coddis AND E.verdis = D.verdis
+                    WHERE E.codeqv = CONVERT(int, :codeqv)
+                    ORDER BY E.coddis
+                ';
+
+                /** @var array<int, array{coddis: string, verdis: int, nomdis: string}> $disciplinas */
+                $disciplinas = ReplicadoDB::fetchAll($disciplinasQuery, ['codeqv' => $codeqv]);
+
+                $equivalencias->push([
+                    'codeqv' => $codeqv,
+                    'disciplinas_equivalentes' => collect($disciplinas),
+                ]);
+            }
+
+            return $equivalencias;
+        } catch (PDOException $e) {
+            throw ReplicadoServiceException::connectionFailed($e);
+        } catch (ReplicadoServiceException $e) {
+            throw $e;
+        } catch (Throwable $e) {
+            throw ReplicadoServiceException::queryFailed('buscarEquivalencias', $e);
         }
     }
 }

--- a/bootstrap/providers.php
+++ b/bootstrap/providers.php
@@ -3,5 +3,6 @@
 return [
     App\Providers\AppServiceProvider::class,
     App\Providers\Filament\AdminPanelProvider::class,
+    App\Providers\ReplicadoServiceProvider::class,
     App\Providers\VoltServiceProvider::class,
 ];


### PR DESCRIPTION
## Summary
Implements the `ReplicadoService` to centralize interactions with the USP Replicado database. This service provides methods for fetching student data, academic history, curriculum structure, and equivalence rules, along with robust error handling.

## Changes Made
- Created `App\Exceptions\ReplicadoServiceException` for custom error handling.
- Created `App\Providers\ReplicadoServiceProvider` to register the service.
- Implemented `App\Services\ReplicadoService` with `buscarAluno`, `buscarHistorico`, `buscarGradeCurricular`, and `buscarEquivalencias` methods.
- Updated `bootstrap/providers.php` to include `ReplicadoServiceProvider`.

## Related Issues
Closes #14